### PR TITLE
Add multi-account support

### DIFF
--- a/.github/workflows/meta_ads_abtest.yml
+++ b/.github/workflows/meta_ads_abtest.yml
@@ -28,6 +28,6 @@ jobs:
         run: python meta_abtest_runner.py
         env:
           ACCESS_TOKEN: ${{ secrets.META_ACCESS_TOKEN }}
-          ACCOUNT_ID: "act_1410377143077190"
+          ACCOUNT_IDS: "act_1410377143077190,act_136286435732155"
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}


### PR DESCRIPTION
## Summary
- support passing multiple Meta ad account IDs via `ACCOUNT_IDS`
- run ad evaluation on both existing and new accounts in CI

## Testing
- `python -m py_compile meta_abtest_runner.py approved_stopper.py`


------
https://chatgpt.com/codex/tasks/task_e_6886de3857408323b5921766043136bb