### PR TITLE
Handle missing credentials gracefully

### DIFF
--- a/approved_stopper.py
+++ b/approved_stopper.py
@@ -1,25 +1,44 @@
-import requests
 import os
+
+import requests
 import gspread
+from dotenv import load_dotenv
 from oauth2client.service_account import ServiceAccountCredentials
+
+load_dotenv()
 
 ACCESS_TOKEN = os.getenv("ACCESS_TOKEN")
 SPREADSHEET_URL = os.getenv("SPREADSHEET_URL")
 SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
 
 # 🔍 トークンの確認ログ
-print("トークンチェック（ACCESS_TOKENの先頭10文字）:", ACCESS_TOKEN[:10])
+if ACCESS_TOKEN:
+    print("トークンチェック（ACCESS_TOKENの先頭10文字）:", ACCESS_TOKEN[:10] + "***")
+else:
+    print("[警告] ACCESS_TOKENが未設定です")
 
 # Google Sheets接続
 def get_sheet():
+    if not SPREADSHEET_URL:
+        print("[警告] SPREADSHEET_URLが未設定のため、シートの読み込みをスキップします")
+        return None
+
     scope = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/auth/drive']
-    creds = ServiceAccountCredentials.from_json_keyfile_name("credentials.json", scope)
-    client = gspread.authorize(creds)
-    sheet = client.open_by_url(SPREADSHEET_URL).sheet1
-    return sheet
+    try:
+        creds = ServiceAccountCredentials.from_json_keyfile_name("credentials.json", scope)
+        client = gspread.authorize(creds)
+        sheet = client.open_by_url(SPREADSHEET_URL).sheet1
+        return sheet
+    except Exception as e:
+        print("[警告] シートの取得に失敗しました:", e)
+        return None
 
 # 広告の現在ステータスを確認
 def fetch_ad_status(ad_id):
+    if not ACCESS_TOKEN:
+        print("[警告] ACCESS_TOKENが未設定のため、広告ステータスの取得をスキップします")
+        return {}
+
     url = f"https://graph.facebook.com/v19.0/{ad_id}?fields=status,effective_status&access_token={ACCESS_TOKEN}"
     res = requests.get(url)
     print(f"広告ステータス確認: {res.text}")
@@ -32,6 +51,10 @@ def pause_ad(ad_id):
 
     if effective_status in ["PAUSED", "ARCHIVED"]:
         print(f"スキップ: {ad_id} はすでに停止済み（ステータス: {effective_status}）")
+        return False
+
+    if not ACCESS_TOKEN:
+        print("[警告] ACCESS_TOKENが未設定のため、広告の停止をスキップします")
         return False
 
     url = f"https://graph.facebook.com/v19.0/{ad_id}"
@@ -57,7 +80,14 @@ def send_slack_confirmation(ad_id, ad_name):
 
 # メイン処理
 def main():
+    if not ACCESS_TOKEN:
+        print("[警告] ACCESS_TOKENが未設定のため、処理を終了します")
+        return
+
     sheet = get_sheet()
+    if not sheet:
+        return
+
     records = sheet.get_all_records()
 
     for row in records:


### PR DESCRIPTION
## Summary
- load .env configuration before fetching credentials in both automation scripts
- add guardrails that skip Meta API and spreadsheet calls when required secrets are missing
- log clear warnings instead of crashing when credentials or URLs are unavailable

## Testing
- python meta_abtest_runner.py
- python approved_stopper.py

------
https://chatgpt.com/codex/tasks/task_e_690a1ae3e5748323846ea4a0d62eee25