### PR TITLE
Handle missing python-dotenv dependency

### DIFF
--- a/approved_stopper.py
+++ b/approved_stopper.py
@@ -2,7 +2,14 @@ import os
 
 import requests
 import gspread
-from dotenv import load_dotenv
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:
+    def load_dotenv(*args, **kwargs):
+        """Fallback when python-dotenv is not installed."""
+        print("[警告] python-dotenvが未インストールのため、.env読み込みをスキップします")
+        return False
 from oauth2client.service_account import ServiceAccountCredentials
 
 load_dotenv()

--- a/meta_abtest_runner.py
+++ b/meta_abtest_runner.py
@@ -2,7 +2,14 @@ import os
 
 import requests
 import gspread
-from dotenv import load_dotenv
+
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:
+    def load_dotenv(*args, **kwargs):
+        """Fallback when python-dotenv is not installed."""
+        print("[警告] python-dotenvが未インストールのため、.env読み込みをスキップします")
+        return False
 from oauth2client.service_account import ServiceAccountCredentials
 
 # 固定設定


### PR DESCRIPTION
## Summary
- add a python-dotenv import fallback so scripts still run when the package is missing
- ensure both the runner and stopper print a warning instead of crashing if python-dotenv is unavailable

## Testing
- python meta_abtest_runner.py
- python approved_stopper.py

------
https://chatgpt.com/codex/tasks/task_e_690a2f949d34832390b24e80d29ed287